### PR TITLE
add stream.readable to split, so that it will continue to get data events after first chunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,6 +333,7 @@ es.split = function (matcher) {
       }
     i++
     }
+    return true;
   }
 
   stream.end = function () {


### PR DESCRIPTION
On larger files that need more than one data event, without having readable set to true, only the first packet is delivered and the stream stops reading as if data were not ready. 

Also the end and close events are never delivered either without this being set to true.
