### PR TITLE
reader and writer arguments swapped in duplex based on usage in connect?

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,6 +476,7 @@ es.stringify = function () {
 
 var setup = function (args) {
   return args.map(function (f) {
+    if (f instanceof Stream) return f;
     var x = f()
       if('function' === typeof x)
         return es.map(x)


### PR DESCRIPTION
If I understand the code properly, it appears to me that the reader and writer arguments are swapped based on how connect is using it. 

The reader is specified first, then the writer.
