### PR TITLE
deprecate es.gate

### DIFF
--- a/index.js
+++ b/index.js
@@ -429,61 +429,6 @@ es.split = function (matcher) {
 }
 
 //
-// gate 
-//
-// while the gate is shut(), buffer incoming. 
-// 
-// if gate is open() stream like normal.
-//
-// currently, when opened, this will emit all data unless it is shut again
-// if downstream pauses it will still write, i'd like to make it respect pause, 
-// but i'll need a test case first.
-
-es.gate = function (shut) {
-
-  var stream = new Stream()
-    , queue = []
-    , ended = false
-
-    shut = (shut === false ? false : true) //default to shut
-
-  stream.writable = true
-  stream.readable = true
-
-  stream.isShut = function () { return shut }
-  stream.shut   = function () { shut = true }
-  stream.open   = function () { shut = false; maybe() }
-  
-  function maybe () {
-    while(queue.length && !shut) {
-      var args = queue.shift()
-      args.unshift('data')
-      stream.emit.apply(stream, args)
-    }
-    stream.emit('drain')
-    if(ended && !shut) 
-      stream.emit('end')
-  }
-  
-  stream.write = function () {
-    var args = [].slice.call(arguments)
-  
-    queue.push(args)
-    if (shut) return false //pause up stream pipes  
-
-    maybe()
-  }
-
-  stream.end = function () {
-    ended = true
-    if (!queue.length)
-      stream.emit('end')
-  }
-
-  return stream
-}
-
-//
 // parse
 //
 // must be used after es.split() to ensure that each chunk represents a line


### PR DESCRIPTION
pause-stream seems to have the same functionality as a seperate module.
