### PR TITLE
Add link to stream-reduce module

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -288,4 +288,22 @@ readStream.pipe(es.join(function (err, text) {
 
 ```
 
+# Other Stream Modules
 
+These modules are not included as a part of *EventStream* but may be
+useful when working with streams.
+
+## [reduce (syncFunction, initial)](https://github.com/parshap/node-stream-reduce)
+
+Like `Array.prototype.reduce` but for streams. Given a sync reduce
+function and an initial value it will return a through stream that emits
+a single data event with the reduced value once the input stream ends.
+
+``` js
+var reduce = require("stream-reduce");
+process.stdin.pipe(reduce(function(acc, data) {
+  return acc + data.length;
+}, 0)).on("data", function(length) {
+  console.log("stdin size:", length);
+});
+```


### PR DESCRIPTION
@dominictarr on #39:

> I'm not gonna merge this, because I now think having things as separate modules it better,
> This module is really just a historical thing now.
> 
> However, I would be more than happy to merge a readme change 
> that added a link to stream-reduce though.

I figured this is a good idea as probably a lot of people new to node streams use this package to learn about streams and the related module ecosystem.

It may also be a good idea to note that this package is not being developed any longer and why separate modules are better. It may also be good to mention that _through_ and _map-stream_ and the rest are separate modules themselves.
