### PR TITLE
Allow adding more than 11 streams to es.merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ es.concat = //actually this should be called concat
 es.merge = function (/*streams...*/) {
   var toMerge = [].slice.call(arguments)
   var stream = new Stream()
+  stream.setMaxListeners(0) // allow adding more than 11 streams
   var endCount = 0
   stream.writable = stream.readable = true
 


### PR DESCRIPTION
This is a better fix for the PR at https://github.com/dominictarr/event-stream/pull/53.
It sets the listener limit to unlimited, but only for the merge stream and not globally. 
Also it will work on more Node versions. :beer: 
