### PR TITLE
Fix bug in merge() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ es.merge = function (/*streams...*/) {
     this.emit('data', data)
   }
   stream.destroy = function () {
-    merge.forEach(function (e) {
+    toMerge.forEach(function (e) {
       if(e.destroy) e.destroy()
     })
   }


### PR DESCRIPTION
If output stream is destroyed input streams are now properly destroyed, too.
There was a typo. :-)
