### PR TITLE
add buffer support for es.wait

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,9 +290,11 @@ es.join = function (str) {
 //
 
 es.wait = function (callback) {
-  var body = ''
-  return es.through(function (data) { body += data },
+  var arr = []
+  return es.through(function (data) { arr.push(data) },
     function () {
+      var body = Buffer.isBuffer(arr[0]) ? Buffer.concat(arr)
+        : arr.join('')
       this.emit('data', body)
       this.emit('end')
       if(callback) callback(null, body)


### PR DESCRIPTION
Chunks should be buffer when using es.wait for concat chunks, as in [gulp-untar](https://github.com/jmerrifield/gulp-untar/blob/master/index.js#L37). And it will result [encode issue](https://github.com/spmjs/spmjs.io/issues/30) if just use `+` to concat.
