### PR TITLE
Add option to .parse() to emit error events for parsing errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,7 +226,7 @@ es.child = function (child) {
 // source.pipe(es.split()).pipe(es.parse())
 
 es.parse = function (options) {
-  var emitError = !!(options ? options.emitError : false)
+  var emitError = !!(options ? options.error : false)
   return es.through(function (data) {
     var obj
     try {

--- a/readme.markdown
+++ b/readme.markdown
@@ -154,8 +154,8 @@ Works just like `string.split(from).join(to)`, but streaming.
 
 Convenience function for parsing JSON chunks. For newline separated JSON,
 use with `es.split`.  By default it logs parsing errors by `console.error`;
-for another behaviour, transforms created by `es.parse({emitError: true})`
-will emit error events for exceptions thrown from `JSON.parse`, unmodified.
+for another behaviour, transforms created by `es.parse({error: true})` will
+emit error events for exceptions thrown from `JSON.parse`, unmodified.
 
 ``` js
 fs.createReadStream(filename)

--- a/test/parse.asynct.js
+++ b/test/parse.asynct.js
@@ -14,8 +14,8 @@ exports ['es.parse() writes parsing errors with console.error'] = function (test
   parseStream.write('A')
 }
 
-exports ['es.parse({emitError: true(thy)}) emits error events from parsing'] = function (test) {
-  var parseStream = es.parse({emitError: 1})
+exports ['es.parse({error: true(thy)}) emits error events from parsing'] = function (test) {
+  var parseStream = es.parse({error: 1})
   var expectedError
   try {
     JSON.parse('A')


### PR DESCRIPTION
Test cases are written for only invalid inputs; should be trivial to write tests for valid inputs, but such cases were untested before, tests for them deserve another commit, I suppose.
