### PR TITLE
Allow Array input for es.concat 

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ es.pipeline = es.connect = es.pipe = pipeline
 es.concat = //actually this should be called concat
 es.merge = function (/*streams...*/) {
   var toMerge = [].slice.call(arguments)
-  if (toMerge.length === 1 && (toMerge instanceof Array)) {
+  if (toMerge.length === 1 && (toMerge[0] instanceof Array)) {
     toMerge = toMerge[0] //handle array as arguments object
   }
   var stream = new Stream()

--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ es.pipeline = es.connect = es.pipe = pipeline
 es.concat = //actually this should be called concat
 es.merge = function (/*streams...*/) {
   var toMerge = [].slice.call(arguments)
+  if (toMerge.length === 1 && (toMerge instanceof Array)) {
+    toMerge = toMerge[0] //handle array as arguments object
+  }
   var stream = new Stream()
   stream.setMaxListeners(0) // allow adding more than 11 streams
   var endCount = 0

--- a/readme.markdown
+++ b/readme.markdown
@@ -130,7 +130,7 @@ Create a through stream that emits `separator` between each chunk, just like Arr
 
 (for legacy reasons, if you pass a callback instead of a string, join is a synonym for `es.wait`)
 
-## merge (stream1,...,streamN)
+## merge (stream1,...,streamN) or merge (streamArray) 
 > concat → merge
 
 Merges streams into one and returns it.
@@ -142,6 +142,14 @@ es.merge(
   process.stdout,
   process.stderr
 ).pipe(fs.createWriteStream('output.log'));
+```
+
+It can also take an Array of streams as input like this: 
+```js
+es.merge([
+  process.stdout, 
+  process.stderr
+]).pipe(fs.createWriteStream('output.log'));
 ```
 
 ## replace (from, to)

--- a/readme.markdown
+++ b/readme.markdown
@@ -147,8 +147,8 @@ es.merge(
 It can also take an Array of streams as input like this: 
 ```js
 es.merge([
-  process.stdout, 
-  process.stderr
+  fs.createReadStream('input1.txt'),
+  fs.createReadStream('input2.txt')
 ]).pipe(fs.createWriteStream('output.log'));
 ```
 

--- a/test/merge.asynct.js
+++ b/test/merge.asynct.js
@@ -8,14 +8,22 @@ exports.merge = function (t) {
 
   var r1 = es.readArray(even)
   var r2 = es.readArray(odd)
+  var endCount = 0
 
   var writer = es.writeArray(function (err, array){
     if(err) throw err //unpossible
     it(array.sort()).deepEqual(even.concat(odd).sort())
-    t.done() 
+    if (++endCount === 2) t.done()
+  })
+
+  var writer2 = es.writeArray(function (err, array){
+    if(err) throw err //unpossible
+    it(array.sort()).deepEqual(even.concat(odd).sort())
+    if (++endCount === 2) t.done()
   })
 
   es.merge(r1, r2).pipe(writer)
+  es.merge([r1, r2]).pipe(writer2)
 
 }
 require('./helper')(module)


### PR DESCRIPTION
Currently `es.concat` does not work if an Array is passed to it. The `arguments` object will look like this: `{"0": streamArray, length: 1}`

That makes the function hard to work with plugins like [gulp-src-files](https://github.com/59naga/gulp-src-files).

I added a check to see if `toMerge` is an array itself or is an object contains an array, also updated asynct file.