### PR TITLE
Handle mapSync() exceptions as stream errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ es.merge = function (/*streams...*/) {
       ended = true
       endCount ++
       if(endCount == toMerge.length)
-        stream.emit('end') 
+        stream.emit('end')
     })
   })
   stream.write = function (data) {
@@ -62,7 +62,7 @@ es.merge = function (/*streams...*/) {
 }
 
 
-// writable stream, collects all events into an array 
+// writable stream, collects all events into an array
 // and calls back when 'end' occurs
 // mainly I'm using this to test the other functions
 
@@ -97,13 +97,13 @@ es.readArray = function (array) {
     , i = 0
     , paused = false
     , ended = false
- 
-  stream.readable = true  
+
+  stream.readable = true
   stream.writable = false
- 
+
   if(!Array.isArray(array))
     throw new Error('event-stream.read expects an array')
-  
+
   stream.resume = function () {
     if(ended) return
     paused = false
@@ -140,16 +140,16 @@ function (func, continueOnError) {
     , ended = false
     , reading = false
 
-  stream.readable = true  
+  stream.readable = true
   stream.writable = false
- 
+
   if('function' !== typeof func)
     throw new Error('event-stream.readable expects async function')
-  
+
   stream.on('end', function () { ended = true })
-  
+
   function get (err, data) {
-    
+
     if(err) {
       stream.emit('error', err)
       if(!continueOnError) stream.emit('end')
@@ -165,7 +165,7 @@ function (func, continueOnError) {
           get.apply(null, arguments)
         })
       } catch (err) {
-        stream.emit('error', err)    
+        stream.emit('error', err)
       }
     })
   }
@@ -190,11 +190,16 @@ function (func, continueOnError) {
 // map sync
 //
 
-es.mapSync = function (sync) { 
+es.mapSync = function (sync) {
   return es.through(function write(data) {
-    var mappedData = sync(data)
-    if (typeof mappedData !== 'undefined')
-      this.emit('data', mappedData)
+    try {
+      var mappedData = sync(data)
+      if (typeof mappedData !== 'undefined')
+        this.emit('data', mappedData)
+    }
+    catch (err) {
+      this.emit('error', err)
+    }
   })
 }
 
@@ -249,33 +254,33 @@ es.parse = function (options) {
 // stringify
 //
 
-es.stringify = function () { 
+es.stringify = function () {
   var Buffer = require('buffer').Buffer
-  return es.mapSync(function (e){ 
+  return es.mapSync(function (e){
     return JSON.stringify(Buffer.isBuffer(e) ? e.toString() : e) + '\n'
-  }) 
+  })
 }
 
 //
 // replace a string within a stream.
 //
-// warn: just concatenates the string and then does str.split().join(). 
+// warn: just concatenates the string and then does str.split().join().
 // probably not optimal.
 // for smallish responses, who cares?
 // I need this for shadow-npm so it's only relatively small json files.
 
 es.replace = function (from, to) {
   return es.pipeline(es.split(from), es.join(to))
-} 
+}
 
 //
 // join chunks with a joiner. just like Array#join
 // also accepts a callback that is passed the chunks appended together
 // this is still supported for legacy reasons.
-// 
+//
 
 es.join = function (str) {
-  
+
   //legacy api
   if('function' === typeof str)
     return es.wait(str)

--- a/index.js
+++ b/index.js
@@ -192,14 +192,14 @@ function (func, continueOnError) {
 
 es.mapSync = function (sync) {
   return es.through(function write(data) {
+    var mappedData
     try {
-      var mappedData = sync(data)
-      if (typeof mappedData !== 'undefined')
-        this.emit('data', mappedData)
-    }
-    catch (err) {
+      mappedData = sync(data)
+    } catch (err) {
       this.emit('error', err)
     }
+    if (mappedData !== undefined)
+      this.emit('data', mappedData)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ es.mapSync = function (sync) {
     try {
       mappedData = sync(data)
     } catch (err) {
-      this.emit('error', err)
+      return this.emit('error', err)
     }
     if (mappedData !== undefined)
       this.emit('data', mappedData)


### PR DESCRIPTION
This patch allows synchronious callback to properly
report errors to the stream by throwing exceptions.

mapSync() will convert them into the stream errors,
catchable with on('error' ...)

https://github.com/dominictarr/event-stream/issues/94

P.S. The trailing spaces got automatically cleaned up by IDE