### PR TITLE
emits "end" if no streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,17 +39,22 @@ es.merge = function (/*streams...*/) {
   var endCount = 0
   stream.writable = stream.readable = true
 
-  toMerge.forEach(function (e) {
-    e.pipe(stream, {end: false})
-    var ended = false
-    e.on('end', function () {
-      if(ended) return
-      ended = true
-      endCount ++
-      if(endCount == toMerge.length)
-        stream.emit('end')
+  if (toMerge.length) {
+    toMerge.forEach(function (e) {
+      e.pipe(stream, {end: false})
+      var ended = false
+      e.on('end', function () {
+        if(ended) return
+        ended = true
+        endCount ++
+        if(endCount == toMerge.length)
+          stream.emit('end')
+      })
     })
-  })
+  } else {
+    process.nextTick(() => stream.emit('end'))
+  }
+  
   stream.write = function (data) {
     this.emit('data', data)
   }

--- a/index.js
+++ b/index.js
@@ -52,7 +52,9 @@ es.merge = function (/*streams...*/) {
       })
     })
   } else {
-    process.nextTick(() => stream.emit('end'))
+    process.nextTick(function () {
+      stream.emit('end')
+    })
   }
   
   stream.write = function (data) {


### PR DESCRIPTION
If there are no streams passed, `es.merge()` should still emit "end". I wasted quite a bit of time because I was merging a variable size array of streams that happen to be empty.