### PR TITLE
fixed undefined error on e.pipe in toMerge.forEach

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ es.merge = function (/*streams...*/) {
 
   if (toMerge.length) {
     toMerge.forEach(function (e) {
+      if(e. == undefined) return
       e.pipe(stream, {end: false})
       var ended = false
       e.on('end', function () {


### PR DESCRIPTION
I just got an error in our project: "TypeError: Cannot read property 'pipe' of undefined ... at /var/www/<my_project>/node_modules/event-stream/index.js:43:6
  at Array.forEach (native) ...".
I don't know why e might be undefined, but this is just a quick fix.