### PR TITLE
Read Me Change Only

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -125,6 +125,18 @@ fs.createReadStream(file, {flags: 'r'})
 `split` takes the same arguments as `string.split` except it defaults to '\n' instead of ',', and the optional `limit` parameter is ignored.
 [String#split](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/String/split)
 
+**NOTE** Maintaining Line Breaks
+If you want to process each line of the stream, transform the data and reassemble and KEEP the line breaks the example will look like this
+```javascript
+fs.createReadStream(file, {flags: 'r'})
+  .pipe(es.split(/(\r?\n)/))
+  .pipe(es.map(function (line, cb) {
+    //do something with the line 
+    cb(null, line)
+  }))
+```
+This is mentioned in the [underlying documentation](https://www.npmjs.com/package/split#keep-matched-splitter) for the split npm package.
+
 ## join (separator)
 
 Create a through stream that emits `separator` between each chunk, just like Array#join.

--- a/readme.markdown
+++ b/readme.markdown
@@ -125,8 +125,8 @@ fs.createReadStream(file, {flags: 'r'})
 `split` takes the same arguments as `string.split` except it defaults to '\n' instead of ',', and the optional `limit` parameter is ignored.
 [String#split](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/String/split)
 
-**NOTE** Maintaining Line Breaks  
-If you want to process each line of the stream, transform the data and reassemble and KEEP the line breaks the example will look like this
+**NOTE**  - Maintaining Line Breaks  
+If you want to process each line of the stream, transform the data, reassemble, and **KEEP** the line breaks the example will look like this:
 
 ```javascript
 fs.createReadStream(file, {flags: 'r'})
@@ -137,7 +137,7 @@ fs.createReadStream(file, {flags: 'r'})
   }))
 ```
 
-This is mentioned in the [underlying documentation](https://www.npmjs.com/package/split#keep-matched-splitter) for the split npm package.
+This technique is mentioned in the [underlying documentation](https://www.npmjs.com/package/split#keep-matched-splitter) for the split npm package.
 
 ## join (separator)
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -125,8 +125,9 @@ fs.createReadStream(file, {flags: 'r'})
 `split` takes the same arguments as `string.split` except it defaults to '\n' instead of ',', and the optional `limit` parameter is ignored.
 [String#split](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/String/split)
 
-**NOTE** Maintaining Line Breaks
+**NOTE** Maintaining Line Breaks  
 If you want to process each line of the stream, transform the data and reassemble and KEEP the line breaks the example will look like this
+
 ```javascript
 fs.createReadStream(file, {flags: 'r'})
   .pipe(es.split(/(\r?\n)/))
@@ -135,6 +136,7 @@ fs.createReadStream(file, {flags: 'r'})
     cb(null, line)
   }))
 ```
+
 This is mentioned in the [underlying documentation](https://www.npmjs.com/package/split#keep-matched-splitter) for the split npm package.
 
 ## join (separator)


### PR DESCRIPTION
I struggled a bit to figure out why all my line breaks were not being maintained. Maintaining line breaks seems like it would be a pretty common use case. The fact that they are lost is a result of the underlying split package. Rather than make other users discover this it seems worthwhile to add a note about this directly to the documentation on your package. 