### PR TITLE
Update map-stream to latest version that has MIT license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,380 @@
+{
+  "name": "event-stream",
+  "version": "3.3.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertions": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/assertions/-/assertions-2.3.4.tgz",
+      "integrity": "sha1-qUM87R/OV8yZmvCWXRAI6WwnluY=",
+      "dev": true,
+      "requires": {
+        "fomatto": "git://github.com/BonsaiDen/Fomatto.git#468666f600b46f9067e3da7200fd9df428923ea6",
+        "render": "0.1.4",
+        "traverser": "1.0.0"
+      },
+      "dependencies": {
+        "traverser": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/traverser/-/traverser-1.0.0.tgz",
+          "integrity": "sha1-b1nlgTdZruqzZGuPRRP9SmLk/iA=",
+          "dev": true,
+          "requires": {
+            "curry": "0.0.4"
+          }
+        }
+      }
+    },
+    "asynct": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/asynct/-/asynct-1.1.0.tgz",
+      "integrity": "sha1-O7LFB9OhPyAAugWGmhp0DCGICRM=",
+      "dev": true,
+      "requires": {
+        "ctrlflow": "0.0.3",
+        "test-cmd": "1.7.0"
+      }
+    },
+    "ctrlflow": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/ctrlflow/-/ctrlflow-0.0.3.tgz",
+      "integrity": "sha1-6WwYCJDcBcKztDc19SmnEpPhOcA=",
+      "dev": true,
+      "requires": {
+        "curry": "0.0.4"
+      }
+    },
+    "curry": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curry/-/curry-0.0.4.tgz",
+      "integrity": "sha1-F1DVGNkZxE89N/9E7caT3h8NX8s=",
+      "dev": true
+    },
+    "d-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d-utils/-/d-utils-2.1.1.tgz",
+      "integrity": "sha1-NZxqACBJUW8ELbnkneMCIE4f7Dw=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+      "dev": true
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "fomatto": {
+      "version": "git://github.com/BonsaiDen/Fomatto.git#468666f600b46f9067e3da7200fd9df428923ea6",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "it-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-is/-/it-is-1.0.3.tgz",
+      "integrity": "sha1-RpcAgZg4pGVu1PF2lT9b/PU/SDs=",
+      "dev": true,
+      "requires": {
+        "assertions": "2.3.4",
+        "render": "0.1.4",
+        "style": "0.1.1",
+        "traverser": "0.0.5",
+        "trees": "0.0.4"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "ls-r": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ls-r/-/ls-r-0.2.1.tgz",
+      "integrity": "sha1-sjmgH6p9QxSIdKZP6xHgrey2b6A=",
+      "dev": true,
+      "requires": {
+        "ctrlflow": "4.1.3",
+        "d-utils": "2.3.3",
+        "optimist": "0.2.8"
+      },
+      "dependencies": {
+        "ctrlflow": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/ctrlflow/-/ctrlflow-4.1.3.tgz",
+          "integrity": "sha1-MCi+xE8BocET/ZIG/E+ZgjN4QoY=",
+          "dev": true,
+          "requires": {
+            "curry": "0.0.4",
+            "d-utils": "1.4.0"
+          },
+          "dependencies": {
+            "d-utils": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/d-utils/-/d-utils-1.4.0.tgz",
+              "integrity": "sha1-RHbSSGduWDLG0Pxp4u0NEMFMn/c=",
+              "dev": true
+            }
+          }
+        },
+        "d-utils": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/d-utils/-/d-utils-2.3.3.tgz",
+          "integrity": "sha1-utm7TWjxLr1VJvU1UI2D4/skFz0=",
+          "dev": true
+        }
+      }
+    },
+    "macgyver": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/macgyver/-/macgyver-1.10.1.tgz",
+      "integrity": "sha1-sJ0VmdizbtWxb1lYlRXZ0UvC/Yg=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+    },
+    "optimist": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
+      "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
+      "dev": true,
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "render": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/render/-/render-0.1.4.tgz",
+      "integrity": "sha1-z7M6NOJgaFkdQYRp4j2Mxc4c7/U=",
+      "dev": true,
+      "requires": {
+        "traverser": "0.0.5"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "should": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
+      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "dev": true,
+      "requires": {
+        "should-equal": "2.0.0",
+        "should-format": "3.0.3",
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "dev": true
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
+    "stream-spec": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/stream-spec/-/stream-spec-0.3.6.tgz",
+      "integrity": "sha1-L92sSge/Pp+JY8Z3prWmzCEVJV4=",
+      "dev": true,
+      "requires": {
+        "macgyver": "1.10.1"
+      }
+    },
+    "style": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/style/-/style-0.1.1.tgz",
+      "integrity": "sha1-4vq2WxuB0+AOvK2FTMWEuiMfJW0=",
+      "dev": true,
+      "requires": {
+        "curry": "0.0.4"
+      }
+    },
+    "tape": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
+      "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "0.1.2",
+        "defined": "0.0.0",
+        "inherits": "2.0.3",
+        "jsonify": "0.0.0",
+        "resumer": "0.0.0",
+        "through": "2.3.8"
+      }
+    },
+    "test-cmd": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/test-cmd/-/test-cmd-1.7.0.tgz",
+      "integrity": "sha1-nldMSfOUcweeLyj+cWF4EtFH4xA=",
+      "dev": true,
+      "requires": {
+        "ctrlflow": "4.1.3",
+        "d-utils": "2.1.1",
+        "ls-r": "0.2.1",
+        "optimist": "0.2.8",
+        "test-report": "1.1.2",
+        "test-report-view": "1.0.0"
+      },
+      "dependencies": {
+        "ctrlflow": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/ctrlflow/-/ctrlflow-4.1.3.tgz",
+          "integrity": "sha1-MCi+xE8BocET/ZIG/E+ZgjN4QoY=",
+          "dev": true,
+          "requires": {
+            "curry": "0.0.4",
+            "d-utils": "1.4.0"
+          },
+          "dependencies": {
+            "d-utils": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/d-utils/-/d-utils-1.4.0.tgz",
+              "integrity": "sha1-RHbSSGduWDLG0Pxp4u0NEMFMn/c=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "test-report": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/test-report/-/test-report-1.1.2.tgz",
+      "integrity": "sha1-nCHcPuk/qpMwTfnl1Zo+ccMBxaQ=",
+      "dev": true
+    },
+    "test-report-view": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/test-report-view/-/test-report-view-1.0.0.tgz",
+      "integrity": "sha1-/Z8/hA/Hsp0/dhNweJ93gFsZ440=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "traverser": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/traverser/-/traverser-0.0.5.tgz",
+      "integrity": "sha1-xm84xFagwhqIAUsSI1gMfr4GMes=",
+      "dev": true,
+      "requires": {
+        "curry": "0.0.4"
+      }
+    },
+    "trees": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/trees/-/trees-0.0.4.tgz",
+      "integrity": "sha1-L1H9m19khvcyyX4R7nVmcja+HVk=",
+      "dev": true,
+      "requires": {
+        "should": "13.2.1",
+        "style": "0.1.1",
+        "traverser": "0.0.5"
+      }
+    },
+    "ubelt": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/ubelt/-/ubelt-3.2.2.tgz",
+      "integrity": "sha1-Ros+spc6rabxe5ff5zL1nZbiOwM=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "through": "~2.3.1",
     "duplexer": "~0.1.1",
     "from": "~0",
-    "map-stream": "~0.1.0",
+    "map-stream": "0.0.7",
     "pause-stream": "0.0.11",
     "split": "0.3",
     "stream-combiner": "~0.0.4"


### PR DESCRIPTION
The version 0.1.0 of map-stream doesn't have a license specified. Update to the latest version 0.0.7 that has MIT license.